### PR TITLE
[feat] 출고(Outgoing) 기능 구현 완료

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
-    <data-source source="LOCAL" name="@localhost" uuid="b01785f2-4fe3-4796-8831-50f47406818f">
+    <data-source source="LOCAL" name="@localhost" uuid="99ab983a-9689-484c-ba22-fdfa8a23e965">
       <driver-ref>mysql.8</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
@@ -13,8 +13,7 @@
       </jdbc-additional-properties>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
-    <data-source source="LOCAL" name="MartGo" uuid="ee1fddaf-475a-41b2-b67a-b10bfb49da05">
-    <data-source source="LOCAL" name="martgo" uuid="9a594786-64aa-48bf-987b-9f860fc5df12">
+    <data-source source="LOCAL" name="martgo" uuid="0cf4d0d5-e03b-489c-bb6f-78b22708c54a">
       <driver-ref>mysql.8</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>

--- a/src/common/constants/MessageEnum.java
+++ b/src/common/constants/MessageEnum.java
@@ -18,7 +18,18 @@ public enum MessageEnum {
     INCOMING_REQUEST_SUCCESS("입고요청이 성공적으로 완료되었습니다."),
     NO_INCOMING_LIST("요청된 입고신청이 없습니다."),
     INPUT_INCOMING_APPROVE("승인할 입고번호를 입력하세요."),
-    INCOMING_APPROVE_SUCCESS("입고요청을 성공적으로 승인하였습니다.");
+    INCOMING_APPROVE_SUCCESS("입고요청을 성공적으로 승인하였습니다."),
+
+    INPUT_OUTGOING_TITLE("\n====== 출고신청 ======"),
+    SHOW_STOCK_TITLE("\n========== 재고 목록 =========="),
+    INPUT_OUTGOING_STOCK_NUM("출고할 재고 번호를 입력하세요."),
+    INPUT_OUTGOING_COUNT("출고할 물품의 개수를 입력하세요."),
+    INPUT_OUTGOING_DATE("출고할 날짜를 입력하세요. (YYYY-MM-DD)"),
+    NO_OUTGOING_LIST("요청된 출고신청이 없습니다."),
+    INPUT_OUTGOING_APPROVE("승인할 출고번호를 입력하세요."),
+    OUTGOING_REQUEST_SUCCESS("출고요청이 성공적으로 완료되었습니다."),
+    OUTGOING_APPROVE_SUCCESS("출고요청을 성공적으로 승인하였습니다.");
+
 
     private final String message;
 

--- a/src/controller/OutgoingController.java
+++ b/src/controller/OutgoingController.java
@@ -1,0 +1,8 @@
+package controller;
+
+import javax.management.relation.Role;
+
+public interface OutgoingController {
+    void requestOutgoing(String userId);
+    void approveOutgoing(String role);
+}

--- a/src/controller/OutgoingControllerImpl.java
+++ b/src/controller/OutgoingControllerImpl.java
@@ -1,0 +1,76 @@
+package controller;
+
+import common.constants.ErrorCode;
+import model.dto.OutgoingDTO;
+import model.service.OutgoingService;
+import model.service.OutgoingServiceImpl;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Scanner;
+
+import static common.constants.MessageEnum.*;
+
+public class OutgoingControllerImpl implements OutgoingController {
+    OutgoingService outgoingService = new OutgoingServiceImpl();
+    Scanner sc = new Scanner(System.in);
+
+    @Override
+    public void requestOutgoing(String userId) {
+        System.out.println(INPUT_OUTGOING_TITLE.getMessage());
+        System.out.println(SHOW_STOCK_TITLE.getMessage());
+
+        outgoingService.showStockByUserId(userId);
+
+        System.out.println(INPUT_OUTGOING_STOCK_NUM.getMessage());
+        int stockNum = Integer.parseInt(sc.nextLine());
+        System.out.println(INPUT_OUTGOING_COUNT.getMessage());
+        int count = Integer.parseInt(sc.nextLine());
+        System.out.println(INPUT_OUTGOING_DATE.getMessage());
+        String date = sc.nextLine();
+
+        Date outgoingDate = null;
+        try {
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+            outgoingDate = sdf.parse(date);
+        } catch (ParseException e) {
+            e.printStackTrace();
+            System.out.println(ErrorCode.INPUT_WRONG_DATE.getMessage());
+            return;
+        }
+
+        OutgoingDTO outgoingDTO = OutgoingDTO.builder()
+                .count(count)
+                .outgoingDate(outgoingDate)
+                .status("대기")
+                .userId(userId)
+                .stockNum(stockNum).build();
+
+        outgoingService.requestOutgoing(outgoingDTO);
+    }
+
+    @Override
+    public void approveOutgoing(String role) {
+        List<OutgoingDTO> outgoingDTOList = outgoingService.getOutgoingByRole(role);
+        if (outgoingDTOList == null || outgoingDTOList.isEmpty()) {
+            System.out.println(NO_OUTGOING_LIST.getMessage());
+            return;
+        }
+        for (OutgoingDTO outgoingDTO : outgoingDTOList) {
+            System.out.println(outgoingDTO);
+        }
+        System.out.println(INPUT_OUTGOING_APPROVE.getMessage());
+        int outgoingNum = Integer.parseInt(sc.nextLine());
+
+        outgoingService.approveOutgoing(outgoingNum, role);
+    }
+
+//    public static void main(String[] args) {
+//        OutgoingControllerImpl outgoingControllerImpl = new OutgoingControllerImpl();
+//        Scanner sc = new Scanner(System.in);
+//        outgoingControllerImpl.requestOutgoing("1");
+//    }
+}

--- a/src/model/dao/OutgoingDAO.java
+++ b/src/model/dao/OutgoingDAO.java
@@ -1,0 +1,13 @@
+package model.dao;
+
+import model.dto.OutgoingDTO;
+import model.dto.StockDTO;
+
+import java.util.List;
+
+public interface OutgoingDAO {
+    List<StockDTO> getStockByUserId(String userId);
+    void insertOutgoing(OutgoingDTO outgoingDTO);
+    List<OutgoingDTO> getOutgoingByStatus(String status);
+    void updateOutgoingStatus(int outgoingNum, String status);
+}

--- a/src/model/dao/OutgoingDAOImpl.java
+++ b/src/model/dao/OutgoingDAOImpl.java
@@ -1,0 +1,110 @@
+package model.dao;
+
+import common.constants.ErrorCode;
+import common.utils.DbUtil;
+import model.dto.OutgoingDTO;
+import model.dto.StockDTO;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class OutgoingDAOImpl implements OutgoingDAO {
+
+    @Override
+    public List<StockDTO> getStockByUserId(String userId) {
+        List<StockDTO> stockDTOList = new ArrayList<>();
+
+        String sql = "SELECT * FROM stock WHERE userid = ?";
+
+        try {
+            Connection conn = DbUtil.getConnection();
+            PreparedStatement ps = conn.prepareStatement(sql);
+            ps.setString(1, userId);
+
+            ResultSet rs = ps.executeQuery();
+            while (rs.next()) {
+                StockDTO stockDTO = StockDTO.builder()
+                        .stock_num(rs.getInt("stock_num"))
+                        .count(rs.getInt("count"))
+                        .total_price(rs.getInt("total_price"))
+                        .user_id(rs.getString("user_id"))
+                        .product_id(rs.getString("product_id"))
+                        .sector_id(rs.getString("sector_id"))
+                        .warehouse_id(rs.getInt("warehouse_id")).build();
+                stockDTOList.add(stockDTO);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+            System.out.println(ErrorCode.DATABASE_ERROR.getMessage());
+        }
+        return stockDTOList;
+    }
+
+    @Override
+    public void insertOutgoing(OutgoingDTO outgoingDTO) {
+
+        String sql = "INSERT INTO outgoing (count, outgoing_date, status, user_id, stock_num) VALUES (?, ?, ?, ?, ?)";
+
+        try {
+            Connection connection = DbUtil.getConnection();
+            PreparedStatement ps = connection.prepareStatement(sql);
+            ps.setInt(1, outgoingDTO.getCount());
+            ps.setDate(2, (Date) outgoingDTO.getOutgoingDate());
+            ps.setString(3, outgoingDTO.getStatus());
+            ps.setString(4, outgoingDTO.getUserId());
+            ps.setInt(5, outgoingDTO.getStockNum());
+            ps.executeUpdate();
+
+        } catch (SQLException e) {
+            e.printStackTrace();
+            System.out.println(ErrorCode.DATABASE_ERROR.getMessage());
+        }
+    }
+
+    @Override
+    public List<OutgoingDTO> getOutgoingByStatus(String status) {
+        List<OutgoingDTO> outgoingDTOList = new ArrayList<>();
+
+        String sql = "SELECT * FROM outgoing WHERE status = ?";
+
+        try {
+            Connection conn = DbUtil.getConnection();
+            PreparedStatement ps = conn.prepareStatement(sql);
+            ps.setString(1, status);
+
+            ResultSet rs = ps.executeQuery();
+            while (rs.next()) {
+                OutgoingDTO outgoingDTO = OutgoingDTO.builder()
+                        .outgoingNum(rs.getInt("outgoing_num"))
+                        .count(rs.getInt("count"))
+                        .outgoingDate(rs.getDate("outgoing_date"))
+                        .status(rs.getString("status"))
+                        .userId(rs.getString("user_id"))
+                        .stockNum(rs.getInt("stock_num")).build();
+                outgoingDTOList.add(outgoingDTO);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return outgoingDTOList;
+    }
+
+    @Override
+    public void updateOutgoingStatus(int outgoingNum, String status) {
+
+        String sql = "UPDATE outgoing SET status = ? WHERE outgoing_num = ?";
+
+        try {
+            Connection conn = DbUtil.getConnection();
+            PreparedStatement ps = conn.prepareStatement(sql);
+            ps.setString(1, status);
+            ps.setInt(2, outgoingNum);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+            System.out.println(ErrorCode.DATABASE_ERROR.getMessage());
+        }
+    }
+}
+

--- a/src/model/dto/OutgoingDTO.java
+++ b/src/model/dto/OutgoingDTO.java
@@ -1,0 +1,21 @@
+package model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OutgoingDTO {
+    private int outgoingNum;
+    private int count;
+    private Date outgoingDate;
+    private String status;
+    private String userId;
+    private int stockNum;
+}

--- a/src/model/dto/StockDTO.java
+++ b/src/model/dto/StockDTO.java
@@ -10,7 +10,7 @@ public class StockDTO {
     Integer stock_num;
     Integer count;
     Integer total_price;
-    String admin_id;
+    String user_id;
     String product_id;
     Integer incoming_num;
     String sector_id;
@@ -25,7 +25,7 @@ public class StockDTO {
         Integer stock_num;
         Integer count;
         Integer total_price;
-        String admin_id;
+        String user_id;
         String product_id;
         Integer incoming_num;
         String sector_id;
@@ -43,8 +43,8 @@ public class StockDTO {
             this.total_price = total_price;
             return this;
         }
-        public StockDTOBuilder admin_id(String admin_id) {
-            this.admin_id = admin_id;
+        public StockDTOBuilder user_id(String user_id) {
+            this.user_id = user_id;
             return this;
         }
         public StockDTOBuilder product_id(String product_id) {
@@ -69,7 +69,7 @@ public class StockDTO {
             stockDTO.stock_num = stock_num;
             stockDTO.count = count;
             stockDTO.total_price = total_price;
-            stockDTO.admin_id = admin_id;
+            stockDTO.user_id = user_id;
             stockDTO.product_id = product_id;
             stockDTO.incoming_num = incoming_num;
             stockDTO.sector_id = sector_id;

--- a/src/model/service/OutgoingService.java
+++ b/src/model/service/OutgoingService.java
@@ -1,0 +1,13 @@
+package model.service;
+
+import model.dto.OutgoingDTO;
+import model.dto.StockDTO;
+
+import java.util.List;
+
+public interface OutgoingService {
+    List<StockDTO> showStockByUserId(String userId);
+    void requestOutgoing(OutgoingDTO outgoingDTO);
+    List<OutgoingDTO> getOutgoingByRole(String role);
+    void approveOutgoing(int outgoingNum, String role);
+}

--- a/src/model/service/OutgoingServiceImpl.java
+++ b/src/model/service/OutgoingServiceImpl.java
@@ -1,0 +1,43 @@
+package model.service;
+
+import common.constants.MessageEnum;
+import model.dao.OutgoingDAO;
+import model.dao.OutgoingDAOImpl;
+import model.dto.OutgoingDTO;
+import model.dto.StockDTO;
+
+import java.util.List;
+
+public class OutgoingServiceImpl implements OutgoingService {
+    OutgoingDAO outgoingDAO = new OutgoingDAOImpl();
+
+    @Override
+    public List<StockDTO> showStockByUserId(String userId) {
+        return outgoingDAO.getStockByUserId(userId);
+    }
+
+    @Override
+    public void requestOutgoing(OutgoingDTO outgoingDTO) {
+        outgoingDAO.insertOutgoing(outgoingDTO);
+        System.out.println(MessageEnum.OUTGOING_REQUEST_SUCCESS.getMessage());
+    }
+
+    @Override
+    public List<OutgoingDTO> getOutgoingByRole(String role) {
+        if (role.equals("창고관리자")) {
+            return outgoingDAO.getOutgoingByStatus("대기");
+        } else if (role.equals("총관리자")) {
+            return outgoingDAO.getOutgoingByStatus("진행중");
+        }
+        return null;
+    }
+
+    @Override
+    public void approveOutgoing(int outgoingNum, String role) {
+        String newStatus = null;
+        if (role.equals("창고관리자")) newStatus = "진행중";
+        else if (role.equals("총관리자")) newStatus = "완료";
+        outgoingDAO.updateOutgoingStatus(outgoingNum, newStatus);
+        System.out.println(MessageEnum.OUTGOING_APPROVE_SUCCESS.getMessage());
+    }
+}


### PR DESCRIPTION
## 사용자가 자신의 재고 목록을 확인한 후 출고 신청 가능하도록 구현
  - 출고 신청 시 입력된 정보를 outgoing 테이블에 저장 (초기 상태 '대기')
  - 창고 관리자가 '대기' → '진행중', 총 관리자가 '진행중' → '완료' 상태로 변경 가능
  - 출고 신청 전 사용자의 재고를 확인하는 기능 추가
  - MessageEnum과 ErrorCode 적용하여 사용자 메시지 및 오류 메시지 통합 관리
  - OutgoingDTO, OutgoingDAO, OutgoingService, OutgoingController 구현 완료
  - OutgoingDAO에서 사용자의 재고를 확인하는 기능 추가 (출고 가능한 재고만 선택 가능)

🔹 관련 테이블: `outgoing`, `stock`
🔹 관련 패키지: `model.dao`, `model.service`, `controller`